### PR TITLE
Expose errors as metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,8 +62,8 @@ func main() {
 	}
 	cfg := slurmrest.NewConfiguration()
 	cfg.HTTPClient = &http.Client{Timeout: time.Second * 3600, Transport: tr}
-    cfg.Scheme = "http"
-    cfg.Host = "localhost"
+	cfg.Scheme = "http"
+	cfg.Host = "localhost"
 
 	client := slurmrest.NewAPIClient(cfg)
 	prometheus.MustRegister(NewNodesCollector(client))

--- a/util.go
+++ b/util.go
@@ -23,12 +23,15 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	// Regexp to parse GPU Gres and GresUsed strings. Example looks like this:
 	//   gpu:tesla_v100-pcie-16gb:2(S:0-1)
 	gpuGresPattern = regexp.MustCompile(`^gpu\:([^\:]+)\:?(\d+)?`)
+	collectError   = prometheus.NewDesc("slurm_exporter_collect_error",
+		"Indicates if an error has occurred during collection", []string{"collector"}, nil)
 )
 
 type Tres struct {


### PR DESCRIPTION
This makes it possible to use Prometheus alerts to know when the SLURM exporter has errors rather than having empty metrics and only logging the issue.