### PR TITLE
Fix flag for nodes

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	ignoreNodeFeatures = kingpin.Flag("collector.node.ignore-features",
+	ignoreNodeFeatures = kingpin.Flag("collector.nodes.ignore-features",
 		"Regular expression of node features to ignore").Default("^$").String()
 	allocPattern   = regexp.MustCompile(`(?i)^ALLOC`)
 	compPattern    = regexp.MustCompile(`(?i)^COMP`)


### PR DESCRIPTION
I copied this from prometheus-slurm-exporter but noticed this exporter uses `nodes` (plural) and also what was used for collector label for error metric, so making things consistent.  Also the collector type is Nodes so also plural.