### PR TITLE
Scheduler and jobs improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ var (
 )
 
 const (
+	namespace     = "slurm"
 	tokenLifespan = 86400
 )
 

--- a/nodes.go
+++ b/nodes.go
@@ -30,6 +30,13 @@ import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
+const (
+	nodesNamespace = "nodes"
+	nodeNamespace  = "node"
+	cpusNamespace  = "cpus"
+	gpusNamespace  = "gpus"
+)
+
 var (
 	ignoreNodeFeatures = kingpin.Flag("collector.nodes.ignore-features",
 		"Regular expression of node features to ignore").Default("^$").String()
@@ -107,32 +114,56 @@ type nodeMetrics struct {
 
 func NewNodesCollector(client *slurmrest.APIClient, logger log.Logger) *NodesCollector {
 	return &NodesCollector{
-		client:       client,
-		logger:       log.With(logger, "collector", "nodes"),
-		alloc:        prometheus.NewDesc("slurm_nodes_alloc", "Allocated nodes", nil, nil),
-		comp:         prometheus.NewDesc("slurm_nodes_comp", "Completing nodes", nil, nil),
-		down:         prometheus.NewDesc("slurm_nodes_down", "Down nodes", nil, nil),
-		drain:        prometheus.NewDesc("slurm_nodes_drain", "Drain nodes", nil, nil),
-		err:          prometheus.NewDesc("slurm_nodes_err", "Error nodes", nil, nil),
-		fail:         prometheus.NewDesc("slurm_nodes_fail", "Fail nodes", nil, nil),
-		idle:         prometheus.NewDesc("slurm_nodes_idle", "Idle nodes", nil, nil),
-		inval:        prometheus.NewDesc("slurm_nodes_invalid", "Invalid nodes", nil, nil),
-		maint:        prometheus.NewDesc("slurm_nodes_maint", "Maint nodes", nil, nil),
-		mix:          prometheus.NewDesc("slurm_nodes_mix", "Mix nodes", nil, nil),
-		planned:      prometheus.NewDesc("slurm_nodes_planned", "Planned nodes", nil, nil),
-		resv:         prometheus.NewDesc("slurm_nodes_resv", "Reserved nodes", nil, nil),
-		total:        prometheus.NewDesc("slurm_nodes_total", "Total nodes", nil, nil),
-		unknown:      prometheus.NewDesc("slurm_nodes_unknown", "Unknown nodes", nil, nil),
-		nodeState:    prometheus.NewDesc("slurm_node_state_info", "Node state", []string{"node", "state"}, nil),
-		nodeDown:     prometheus.NewDesc("slurm_node_down", "Indicates if a node is down, 1=down 0=not down", []string{"node", "reason"}, nil),
-		nodeFeatures: prometheus.NewDesc("slurm_node_features_info", "Node features", []string{"node", "features"}, nil),
-		cpuAlloc:     prometheus.NewDesc("slurm_cpus_alloc", "Allocated CPUs", nil, nil),
-		cpuIdle:      prometheus.NewDesc("slurm_cpus_idle", "Idle CPUs", nil, nil),
-		cpuOther:     prometheus.NewDesc("slurm_cpus_other", "Mix CPUs", nil, nil),
-		cpuTotal:     prometheus.NewDesc("slurm_cpus_total", "Total CPUs", nil, nil),
-		gpuAlloc:     prometheus.NewDesc("slurm_gpus_alloc", "Allocated GPUs", nil, nil),
-		gpuIdle:      prometheus.NewDesc("slurm_gpus_idle", "Idle GPUs", nil, nil),
-		gpuTotal:     prometheus.NewDesc("slurm_gpus_total", "Total GPUs", nil, nil),
+		client: client,
+		logger: log.With(logger, "collector", "nodes"),
+		alloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "alloc"),
+			"Allocated nodes", nil, nil),
+		comp: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "comp"),
+			"Completing nodes", nil, nil),
+		down: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "down"),
+			"Down nodes", nil, nil),
+		drain: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "drain"),
+			"Drain nodes", nil, nil),
+		err: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "err"),
+			"Error nodes", nil, nil),
+		fail: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "fail"),
+			"Fail nodes", nil, nil),
+		idle: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "idle"),
+			"Idle nodes", nil, nil),
+		inval: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "invalid"),
+			"Invalid nodes", nil, nil),
+		maint: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "maint"),
+			"Maint nodes", nil, nil),
+		mix: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "mix"),
+			"Mix nodes", nil, nil),
+		planned: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "planned"),
+			"Planned nodes", nil, nil),
+		resv: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "resv"),
+			"Reserved nodes", nil, nil),
+		total: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "total"),
+			"Total nodes", nil, nil),
+		unknown: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodesNamespace, "unknown"),
+			"Unknown nodes", nil, nil),
+		nodeState: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodeNamespace, "state_info"),
+			"Node state", []string{"node", "state"}, nil),
+		nodeDown: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodeNamespace, "down"),
+			"Indicates if a node is down, 1=down 0=not down", []string{"node", "reason"}, nil),
+		nodeFeatures: prometheus.NewDesc(prometheus.BuildFQName(namespace, nodeNamespace, "features_info"),
+			"Node features", []string{"node", "features"}, nil),
+		cpuAlloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, cpusNamespace, "alloc"),
+			"Allocated CPUs", nil, nil),
+		cpuIdle: prometheus.NewDesc(prometheus.BuildFQName(namespace, cpusNamespace, "idle"),
+			"Idle CPUs", nil, nil),
+		cpuOther: prometheus.NewDesc(prometheus.BuildFQName(namespace, cpusNamespace, "other"),
+			"Mix CPUs", nil, nil),
+		cpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, cpusNamespace, "total"),
+			"Total CPUs", nil, nil),
+		gpuAlloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, gpusNamespace, "alloc"),
+			"Allocated GPUs", nil, nil),
+		gpuIdle: prometheus.NewDesc(prometheus.BuildFQName(namespace, gpusNamespace, "idle"),
+			"Idle GPUs", nil, nil),
+		gpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, gpusNamespace, "total"),
+			"Total GPUs", nil, nil),
 	}
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -27,28 +27,68 @@ import (
 	"github.com/ubccr/slurmrest"
 )
 
+const (
+	schedulerNamespace = "scheduler"
+)
+
 type SchedulerCollector struct {
-	client            *slurmrest.APIClient
-	logger            log.Logger
-	threads           *prometheus.Desc
-	queueSize         *prometheus.Desc
-	lastCycle         *prometheus.Desc
-	meanCycle         *prometheus.Desc
-	cyclePerMinute    *prometheus.Desc
-	backfillLastCycle *prometheus.Desc
-	backfillMeanCycle *prometheus.Desc
-	backfillDepthMean *prometheus.Desc
+	client                         *slurmrest.APIClient
+	logger                         log.Logger
+	threads                        *prometheus.Desc
+	agentQueueSize                 *prometheus.Desc
+	agentCount                     *prometheus.Desc
+	agentThreadCount               *prometheus.Desc
+	dbdQueueSize                   *prometheus.Desc
+	maxCycle                       *prometheus.Desc
+	lastCycle                      *prometheus.Desc
+	totalCycle                     *prometheus.Desc
+	meanCycle                      *prometheus.Desc
+	cycleMeanDepth                 *prometheus.Desc
+	cyclePerMinute                 *prometheus.Desc
+	queueLength                    *prometheus.Desc
+	backfillLastCycle              *prometheus.Desc
+	backfillMeanCycle              *prometheus.Desc
+	backfillMaxCycle               *prometheus.Desc
+	backfillDepthMean              *prometheus.Desc
+	backfillDepthMeanTrySched      *prometheus.Desc
+	backfillLastDepthCycle         *prometheus.Desc
+	backfillLastDepthCycleTrySched *prometheus.Desc
+	backfillLastQueueLength        *prometheus.Desc
+	backfillQueueLengthMean        *prometheus.Desc
+	backfillLastTableSize          *prometheus.Desc
+	backfillMeanTableSize          *prometheus.Desc
+	totalBackfilledJobsSinceStart  *prometheus.Desc
+	totalBackfilledJobsSinceCycle  *prometheus.Desc
+	totalBackfilledHeterogeneous   *prometheus.Desc
 }
 
 type diagMetrics struct {
-	threads           float64
-	queueSize         float64
-	lastCycle         float64
-	meanCycle         float64
-	cyclePerMinute    float64
-	backfillLastCycle float64
-	backfillMeanCycle float64
-	backfillDepthMean float64
+	threads                        float64
+	agentQueueSize                 float64
+	agentCount                     float64
+	agentThreadCount               float64
+	dbdQueueSize                   float64
+	maxCycle                       float64
+	lastCycle                      float64
+	totalCycle                     float64
+	meanCycle                      float64
+	cycleMeanDepth                 float64
+	cyclePerMinute                 float64
+	queueLength                    float64
+	backfillLastCycle              float64
+	backfillMeanCycle              float64
+	backfillMaxCycle               float64
+	backfillDepthMean              float64
+	backfillDepthMeanTrySched      float64
+	backfillLastDepthCycle         float64
+	backfillLastDepthCycleTrySched float64
+	backfillLastQueueLength        float64
+	backfillQueueLengthMean        float64
+	backfillLastTableSize          float64
+	backfillMeanTableSize          float64
+	totalBackfilledJobsSinceStart  float64
+	totalBackfilledJobsSinceCycle  float64
+	totalBackfilledHeterogeneous   float64
 }
 
 func NewSchedulerCollector(client *slurmrest.APIClient, logger log.Logger) *SchedulerCollector {
@@ -56,43 +96,133 @@ func NewSchedulerCollector(client *slurmrest.APIClient, logger log.Logger) *Sche
 		client: client,
 		logger: log.With(logger, "collector", "scheduler"),
 		threads: prometheus.NewDesc(
-			"slurm_scheduler_threads",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "threads"),
 			"Information provided by the Slurm sdiag command, number of scheduler threads ",
 			nil,
 			nil),
-		queueSize: prometheus.NewDesc(
-			"slurm_scheduler_queue_size",
-			"Information provided by the Slurm sdiag command, length of the scheduler queue",
+		agentQueueSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "agent_queue_size"),
+			"Information provided by the Slurm sdiag command, agent queue size",
+			nil,
+			nil),
+		agentCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "agent_count"),
+			"Information provided by the Slurm sdiag command, number of agent threads",
+			nil,
+			nil),
+		agentThreadCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "agent_thread_count"),
+			"Information provided by the Slurm sdiag command, active agent threads",
+			nil,
+			nil),
+		dbdQueueSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "dbd_queue_size"),
+			"Information provided by the Slurm sdiag command, length of the DBD agent queue",
+			nil,
+			nil),
+		maxCycle: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "max_cycle"),
+			"Information provided by the Slurm sdiag command, scheduler max cycle time in (microseconds)",
 			nil,
 			nil),
 		lastCycle: prometheus.NewDesc(
-			"slurm_scheduler_last_cycle",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "last_cycle"),
 			"Information provided by the Slurm sdiag command, scheduler last cycle time in (microseconds)",
 			nil,
 			nil),
+		totalCycle: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "total_cycle"),
+			"Information provided by the Slurm sdiag command, scheduler total cycle iterations",
+			nil,
+			nil),
 		meanCycle: prometheus.NewDesc(
-			"slurm_scheduler_mean_cycle",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "mean_cycle"),
 			"Information provided by the Slurm sdiag command, scheduler mean cycle time in (microseconds)",
 			nil,
 			nil),
+		cycleMeanDepth: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "cycle_mean_depth"),
+			"Information provided by the Slurm sdiag command, average depth of schedule max cycle",
+			nil,
+			nil),
 		cyclePerMinute: prometheus.NewDesc(
-			"slurm_scheduler_cycle_per_minute",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "cycle_per_minute"),
 			"Information provided by the Slurm sdiag command, number scheduler cycles per minute",
 			nil,
 			nil),
+		queueLength: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "last_queue_length"),
+			"Information provided by the Slurm sdiag command, main schedule last queue length",
+			nil,
+			nil),
 		backfillLastCycle: prometheus.NewDesc(
-			"slurm_scheduler_backfill_last_cycle",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_last_cycle"),
 			"Information provided by the Slurm sdiag command, scheduler backfill last cycle time in (microseconds)",
 			nil,
 			nil),
 		backfillMeanCycle: prometheus.NewDesc(
-			"slurm_scheduler_backfill_mean_cycle",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_mean_cycle"),
 			"Information provided by the Slurm sdiag command, scheduler backfill mean cycle time in (microseconds)",
 			nil,
 			nil),
+		backfillMaxCycle: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_max_cycle"),
+			"Information provided by the Slurm sdiag command, scheduler backfill max cycle time in (microseconds)",
+			nil,
+			nil),
 		backfillDepthMean: prometheus.NewDesc(
-			"slurm_scheduler_backfill_depth_mean",
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_depth_mean"),
 			"Information provided by the Slurm sdiag command, scheduler backfill mean depth",
+			nil,
+			nil),
+		backfillDepthMeanTrySched: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_depth_mean_try_sched"),
+			"Information provided by the Slurm sdiag command, scheduler backfill mean depth (try sched)",
+			nil,
+			nil),
+		backfillLastDepthCycle: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_last_depth_cycle"),
+			"Information provided by the Slurm sdiag command, scheduler backfill last depth cycle",
+			nil,
+			nil),
+		backfillLastDepthCycleTrySched: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_last_depth_cycle_try_sched"),
+			"Information provided by the Slurm sdiag command, scheduler backfill last depth cycle (try sched)",
+			nil,
+			nil),
+		backfillLastQueueLength: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_last_queue_length"),
+			"Information provided by the Slurm sdiag command, scheduler backfill last queye length",
+			nil,
+			nil),
+		backfillQueueLengthMean: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_queue_length_mean"),
+			"Information provided by the Slurm sdiag command, scheduler backfill queue length mean",
+			nil,
+			nil),
+		backfillLastTableSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_last_table_size"),
+			"Information provided by the Slurm sdiag command, scheduler backfill last table size",
+			nil,
+			nil),
+		backfillMeanTableSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfill_mean_table_size"),
+			"Information provided by the Slurm sdiag command, scheduler backfill mean table size",
+			nil,
+			nil),
+		totalBackfilledJobsSinceStart: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfilled_jobs_since_start_total"),
+			"Information provided by the Slurm sdiag command, number of jobs started thanks to backfilling since last slurm start",
+			nil,
+			nil),
+		totalBackfilledJobsSinceCycle: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfilled_jobs_since_cycle_total"),
+			"Information provided by the Slurm sdiag command, number of jobs started thanks to backfilling since last time stats where reset",
+			nil,
+			nil),
+		totalBackfilledHeterogeneous: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, schedulerNamespace, "backfilled_heterogeneous_total"),
+			"Information provided by the Slurm sdiag command, number of heterogeneous job components started thanks to backfilling since last Slurm start",
 			nil,
 			nil),
 	}
@@ -118,26 +248,61 @@ func (sc *SchedulerCollector) metrics() (*diagMetrics, error) {
 	}
 
 	dm.threads = float64(diag.Statistics.GetServerThreadCount())
-	dm.queueSize = float64(diag.Statistics.GetAgentQueueSize())
+	dm.agentQueueSize = float64(diag.Statistics.GetAgentQueueSize())
+	dm.agentCount = float64(diag.Statistics.GetAgentCount())
+	dm.agentThreadCount = float64(diag.Statistics.GetAgentThreadCount())
+	dm.dbdQueueSize = float64(diag.Statistics.GetDbdAgentQueueSize())
+	dm.maxCycle = float64(diag.Statistics.GetScheduleCycleMax())
 	dm.lastCycle = float64(diag.Statistics.GetScheduleCycleLast())
+	dm.totalCycle = float64(diag.Statistics.GetScheduleCycleTotal())
 	dm.meanCycle = float64(diag.Statistics.GetScheduleCycleMean())
+	dm.cycleMeanDepth = float64(diag.Statistics.GetScheduleCycleMeanDepth())
 	dm.cyclePerMinute = float64(diag.Statistics.GetScheduleCyclePerMinute())
+	dm.queueLength = float64(diag.Statistics.GetScheduleQueueLength())
 	dm.backfillLastCycle = float64(diag.Statistics.GetBfCycleLast())
 	dm.backfillMeanCycle = float64(diag.Statistics.GetBfCycleMean())
+	dm.backfillMaxCycle = float64(diag.Statistics.GetBfCycleMax())
 	dm.backfillDepthMean = float64(diag.Statistics.GetBfDepthMean())
+	dm.backfillDepthMeanTrySched = float64(diag.Statistics.GetBfDepthMeanTry())
+	dm.backfillLastDepthCycle = float64(diag.Statistics.GetBfLastDepth())
+	dm.backfillLastDepthCycleTrySched = float64(diag.Statistics.GetBfLastDepthTry())
+	dm.backfillLastQueueLength = float64(diag.Statistics.GetBfQueueLen())
+	dm.backfillQueueLengthMean = float64(diag.Statistics.GetBfQueueLenMean())
+	dm.backfillLastTableSize = float64(diag.Statistics.GetBfTableSize())
+	dm.backfillMeanTableSize = float64(diag.Statistics.GetBfTableSizeMean())
+	dm.totalBackfilledJobsSinceStart = float64(diag.Statistics.GetBfBackfilledJobs())
+	dm.totalBackfilledJobsSinceCycle = float64(diag.Statistics.GetBfLastBackfilledJobs())
+	dm.totalBackfilledHeterogeneous = float64(diag.Statistics.GetBfBackfilledHetJobs())
 
 	return &dm, nil
 }
 
 func (sc *SchedulerCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- sc.threads
-	ch <- sc.queueSize
+	ch <- sc.agentQueueSize
+	ch <- sc.agentThreadCount
+	ch <- sc.dbdQueueSize
+	ch <- sc.maxCycle
 	ch <- sc.lastCycle
+	ch <- sc.totalCycle
 	ch <- sc.meanCycle
+	ch <- sc.cycleMeanDepth
 	ch <- sc.cyclePerMinute
+	ch <- sc.queueLength
 	ch <- sc.backfillLastCycle
 	ch <- sc.backfillMeanCycle
+	ch <- sc.backfillMaxCycle
 	ch <- sc.backfillDepthMean
+	ch <- sc.backfillDepthMeanTrySched
+	ch <- sc.backfillLastDepthCycle
+	ch <- sc.backfillLastDepthCycleTrySched
+	ch <- sc.backfillLastQueueLength
+	ch <- sc.backfillQueueLengthMean
+	ch <- sc.backfillLastTableSize
+	ch <- sc.backfillMeanTableSize
+	ch <- sc.totalBackfilledJobsSinceStart
+	ch <- sc.totalBackfilledJobsSinceCycle
+	ch <- sc.totalBackfilledHeterogeneous
 }
 
 func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) {
@@ -147,12 +312,30 @@ func (sc *SchedulerCollector) Collect(ch chan<- prometheus.Metric) {
 		errValue = 1
 	}
 	ch <- prometheus.MustNewConstMetric(sc.threads, prometheus.GaugeValue, sm.threads)
-	ch <- prometheus.MustNewConstMetric(sc.queueSize, prometheus.GaugeValue, sm.queueSize)
+	ch <- prometheus.MustNewConstMetric(sc.agentQueueSize, prometheus.GaugeValue, sm.agentQueueSize)
+	ch <- prometheus.MustNewConstMetric(sc.agentCount, prometheus.GaugeValue, sm.agentCount)
+	ch <- prometheus.MustNewConstMetric(sc.agentThreadCount, prometheus.GaugeValue, sm.agentThreadCount)
+	ch <- prometheus.MustNewConstMetric(sc.dbdQueueSize, prometheus.GaugeValue, sm.dbdQueueSize)
+	ch <- prometheus.MustNewConstMetric(sc.maxCycle, prometheus.GaugeValue, sm.maxCycle)
 	ch <- prometheus.MustNewConstMetric(sc.lastCycle, prometheus.GaugeValue, sm.lastCycle)
+	ch <- prometheus.MustNewConstMetric(sc.totalCycle, prometheus.GaugeValue, sm.totalCycle)
 	ch <- prometheus.MustNewConstMetric(sc.meanCycle, prometheus.GaugeValue, sm.meanCycle)
+	ch <- prometheus.MustNewConstMetric(sc.cycleMeanDepth, prometheus.GaugeValue, sm.cycleMeanDepth)
 	ch <- prometheus.MustNewConstMetric(sc.cyclePerMinute, prometheus.GaugeValue, sm.cyclePerMinute)
+	ch <- prometheus.MustNewConstMetric(sc.queueLength, prometheus.GaugeValue, sm.queueLength)
 	ch <- prometheus.MustNewConstMetric(sc.backfillLastCycle, prometheus.GaugeValue, sm.backfillLastCycle)
 	ch <- prometheus.MustNewConstMetric(sc.backfillMeanCycle, prometheus.GaugeValue, sm.backfillMeanCycle)
+	ch <- prometheus.MustNewConstMetric(sc.backfillMaxCycle, prometheus.GaugeValue, sm.backfillMaxCycle)
 	ch <- prometheus.MustNewConstMetric(sc.backfillDepthMean, prometheus.GaugeValue, sm.backfillDepthMean)
+	ch <- prometheus.MustNewConstMetric(sc.backfillDepthMeanTrySched, prometheus.GaugeValue, sm.backfillDepthMeanTrySched)
+	ch <- prometheus.MustNewConstMetric(sc.backfillLastDepthCycle, prometheus.GaugeValue, sm.backfillLastDepthCycle)
+	ch <- prometheus.MustNewConstMetric(sc.backfillLastDepthCycleTrySched, prometheus.GaugeValue, sm.backfillLastDepthCycleTrySched)
+	ch <- prometheus.MustNewConstMetric(sc.backfillLastQueueLength, prometheus.GaugeValue, sm.backfillLastQueueLength)
+	ch <- prometheus.MustNewConstMetric(sc.backfillQueueLengthMean, prometheus.GaugeValue, sm.backfillQueueLengthMean)
+	ch <- prometheus.MustNewConstMetric(sc.backfillLastTableSize, prometheus.GaugeValue, sm.backfillLastTableSize)
+	ch <- prometheus.MustNewConstMetric(sc.backfillMeanTableSize, prometheus.GaugeValue, sm.backfillMeanTableSize)
+	ch <- prometheus.MustNewConstMetric(sc.totalBackfilledJobsSinceStart, prometheus.GaugeValue, sm.totalBackfilledJobsSinceStart)
+	ch <- prometheus.MustNewConstMetric(sc.totalBackfilledJobsSinceCycle, prometheus.GaugeValue, sm.totalBackfilledJobsSinceCycle)
+	ch <- prometheus.MustNewConstMetric(sc.totalBackfilledHeterogeneous, prometheus.GaugeValue, sm.totalBackfilledHeterogeneous)
 	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, errValue, "scheduler")
 }

--- a/util.go
+++ b/util.go
@@ -49,6 +49,12 @@ type Token struct {
 	created int64
 }
 
+type rpcStat struct {
+	count     float64
+	aveTime   float64
+	totalTime float64
+}
+
 // gpuCountFromGres parses Slurm GRES (generic resource) line and returns the
 // count of GPUs
 func gpuCountFromGres(line string) int {


### PR DESCRIPTION
Only thing really changed is I renamed `slurm_scheduler_queue_size` to `slurm_scheduler_agent_queue_size` to match the API name more closely. 

Added total jobs and total GPU jobs metrics

Use `prometheus.BuildFQName` to build metric names.  Just a safe guard against typos in metric names and a pattern I've seen used on Prometheus developed exporters.

Add many new metrics to scheduler collector.