### PR TITLE
Add per-partition metrics and fix how node states are pulled

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -35,71 +35,79 @@ const (
 )
 
 type JobsCollector struct {
-	client         *slurmrest.APIClient
-	logger         log.Logger
-	pending        *prometheus.Desc
-	pendingDep     *prometheus.Desc
-	running        *prometheus.Desc
-	suspended      *prometheus.Desc
-	cancelled      *prometheus.Desc
-	completing     *prometheus.Desc
-	completed      *prometheus.Desc
-	configuring    *prometheus.Desc
-	failed         *prometheus.Desc
-	timeout        *prometheus.Desc
-	preempted      *prometheus.Desc
-	nodeFail       *prometheus.Desc
-	total          *prometheus.Desc
-	waitTime       *prometheus.Desc
-	waitTimeGpu    *prometheus.Desc
-	startTime      *prometheus.Desc
-	startTimeGpu   *prometheus.Desc
-	gpuPending     *prometheus.Desc
-	gpuPendingDep  *prometheus.Desc
-	gpuRunning     *prometheus.Desc
-	gpuSuspended   *prometheus.Desc
-	gpuCancelled   *prometheus.Desc
-	gpuCompleting  *prometheus.Desc
-	gpuCompleted   *prometheus.Desc
-	gpuConfiguring *prometheus.Desc
-	gpuFailed      *prometheus.Desc
-	gpuTimeout     *prometheus.Desc
-	gpuPreempted   *prometheus.Desc
-	gpuNodeFail    *prometheus.Desc
-	gpuTotal       *prometheus.Desc
+	client             *slurmrest.APIClient
+	logger             log.Logger
+	pending            *prometheus.Desc
+	pendingDep         *prometheus.Desc
+	running            *prometheus.Desc
+	suspended          *prometheus.Desc
+	cancelled          *prometheus.Desc
+	completing         *prometheus.Desc
+	completed          *prometheus.Desc
+	configuring        *prometheus.Desc
+	failed             *prometheus.Desc
+	timeout            *prometheus.Desc
+	preempted          *prometheus.Desc
+	nodeFail           *prometheus.Desc
+	total              *prometheus.Desc
+	medianWaitTime     *prometheus.Desc
+	avgWaitTime        *prometheus.Desc
+	medianStartTime    *prometheus.Desc
+	avgStartTime       *prometheus.Desc
+	gpuPending         *prometheus.Desc
+	gpuPendingDep      *prometheus.Desc
+	gpuRunning         *prometheus.Desc
+	gpuSuspended       *prometheus.Desc
+	gpuCancelled       *prometheus.Desc
+	gpuCompleting      *prometheus.Desc
+	gpuCompleted       *prometheus.Desc
+	gpuConfiguring     *prometheus.Desc
+	gpuFailed          *prometheus.Desc
+	gpuTimeout         *prometheus.Desc
+	gpuPreempted       *prometheus.Desc
+	gpuNodeFail        *prometheus.Desc
+	gpuTotal           *prometheus.Desc
+	gpuMedianWaitTime  *prometheus.Desc
+	gpuAvgWaitTime     *prometheus.Desc
+	gpuMedianStartTime *prometheus.Desc
+	gpuAvgStartTime    *prometheus.Desc
 }
 
 type jobMetrics struct {
-	pending        float64
-	pendingDep     float64
-	running        float64
-	suspended      float64
-	cancelled      float64
-	completing     float64
-	completed      float64
-	configuring    float64
-	failed         float64
-	timeout        float64
-	preempted      float64
-	nodeFail       float64
-	total          float64
-	waitTime       float64
-	waitTimeGpu    float64
-	startTime      float64
-	startTimeGpu   float64
-	gpuPending     float64
-	gpuPendingDep  float64
-	gpuRunning     float64
-	gpuSuspended   float64
-	gpuCancelled   float64
-	gpuCompleting  float64
-	gpuCompleted   float64
-	gpuConfiguring float64
-	gpuFailed      float64
-	gpuTimeout     float64
-	gpuPreempted   float64
-	gpuNodeFail    float64
-	gpuTotal       float64
+	pending            float64
+	pendingDep         float64
+	running            float64
+	suspended          float64
+	cancelled          float64
+	completing         float64
+	completed          float64
+	configuring        float64
+	failed             float64
+	timeout            float64
+	preempted          float64
+	nodeFail           float64
+	total              float64
+	medianWaitTime     float64
+	avgWaitTime        float64
+	medianStartTime    float64
+	avgStartTime       float64
+	gpuPending         float64
+	gpuPendingDep      float64
+	gpuRunning         float64
+	gpuSuspended       float64
+	gpuCancelled       float64
+	gpuCompleting      float64
+	gpuCompleted       float64
+	gpuConfiguring     float64
+	gpuFailed          float64
+	gpuTimeout         float64
+	gpuPreempted       float64
+	gpuNodeFail        float64
+	gpuTotal           float64
+	gpuMedianWaitTime  float64
+	gpuAvgWaitTime     float64
+	gpuMedianStartTime float64
+	gpuAvgStartTime    float64
 }
 
 func NewJobsCollector(client *slurmrest.APIClient, logger log.Logger) *JobsCollector {
@@ -132,14 +140,14 @@ func NewJobsCollector(client *slurmrest.APIClient, logger log.Logger) *JobsColle
 			"Number of jobs stopped due to node fail", nil, nil),
 		total: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "total"),
 			"Total jobs in the cluster", nil, nil),
-		waitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "wait_time"),
-			"Mean wait time of pending jobs", nil, nil),
-		waitTimeGpu: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "wait_time_gpu"),
-			"Mean wait time of pending jobs that requested GPU", nil, nil),
-		startTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "start_time"),
+		medianWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "median_wait_time_seconds"),
+			"Median wait time of pending jobs", nil, nil),
+		avgWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "average_wait_time_seconds"),
+			"Average wait time of pending jobs", nil, nil),
+		medianStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "median_start_time_seconds"),
 			"Mean estimated start time of pending jobs", nil, nil),
-		startTimeGpu: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "start_time_gpu"),
-			"Mean estimated start time of pending jobs that requested GPU", nil, nil),
+		avgStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, queueNamespace, "average_start_time_seconds"),
+			"Average estimated start time of pending jobs", nil, nil),
 		gpuPending: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "pending"),
 			"Pending gres/gpu jobs in queue", nil, nil),
 		gpuPendingDep: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "pending_dependency"),
@@ -166,6 +174,14 @@ func NewJobsCollector(client *slurmrest.APIClient, logger log.Logger) *JobsColle
 			"Number of gres/gpu jobs stopped due to node fail", nil, nil),
 		gpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "total"),
 			"Total gres/gpu jobs in the cluster", nil, nil),
+		gpuMedianWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "median_wait_time_seconds"),
+			"Median wait time of pending jobs that requested GPU", nil, nil),
+		gpuAvgWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "average_wait_time_seconds"),
+			"Average wait time of pending jobs that requested GPU", nil, nil),
+		gpuMedianStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "median_start_time_seconds"),
+			"Median estimated start time of pending jobs that requested GPU", nil, nil),
+		gpuAvgStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, gresGPUNamespace, "average_start_time_seconds"),
+			"Average estimated start time of pending jobs that requested GPU", nil, nil),
 	}
 }
 
@@ -188,7 +204,7 @@ func (jc *JobsCollector) metrics() (*jobMetrics, error) {
 		return &jm, fmt.Errorf("HTTP response contained %d errors", len(jobs.GetErrors()))
 	}
 
-	var waitTimes, waitTimesGpu, startTimes, startTimesGpu []float64
+	var waitTimes, gpuWaitTimes, startTimes, gpuStartTimes []float64
 	now := time.Now().Unix()
 
 	for _, j := range jobs.GetJobs() {
@@ -215,13 +231,13 @@ func (jc *JobsCollector) metrics() (*jobMetrics, error) {
 			if startTime >= 0 {
 				startTimes = append(startTimes, float64(startTime))
 				if tres.GresGpu > 0 {
-					startTimesGpu = append(startTimesGpu, float64(startTime))
+					gpuStartTimes = append(gpuStartTimes, float64(startTime))
 				}
 			}
 			waitTime := now - j.GetSubmitTime()
 			waitTimes = append(waitTimes, float64(waitTime))
 			if tres.GresGpu > 0 {
-				waitTimesGpu = append(waitTimesGpu, float64(waitTime))
+				gpuWaitTimes = append(gpuWaitTimes, float64(waitTime))
 			}
 		case "RUNNING":
 			jm.running++
@@ -276,33 +292,53 @@ func (jc *JobsCollector) metrics() (*jobMetrics, error) {
 		}
 	}
 
-	if len(waitTimes) == 0 {
-		jm.waitTime = 0
-	} else if waitTime, err := stats.Mean(waitTimes); err != nil {
-		level.Error(jc.logger).Log("msg", "Unable to calculate mean wait time", "err", err)
-	} else {
-		jm.waitTime = waitTime
+	if len(waitTimes) > 0 {
+		if waitTime, err := stats.Median(waitTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate median wait time", "err", err)
+		} else {
+			jm.medianWaitTime = waitTime
+		}
+		if waitTime, err := stats.Mean(waitTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate average wait time", "err", err)
+		} else {
+			jm.avgWaitTime = waitTime
+		}
 	}
-	if len(waitTimesGpu) == 0 {
-		jm.waitTimeGpu = 0
-	} else if waitTimeGpu, err := stats.Mean(waitTimesGpu); err != nil {
-		level.Error(jc.logger).Log("msg", "Unable to calculate mean GPU wait time", "err", err)
-	} else {
-		jm.waitTimeGpu = waitTimeGpu
+	if len(gpuWaitTimes) > 0 {
+		if gpuWaitTime, err := stats.Median(gpuWaitTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate median GPU wait time", "err", err)
+		} else {
+			jm.gpuMedianWaitTime = gpuWaitTime
+		}
+		if gpuWaitTime, err := stats.Mean(gpuWaitTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate average GPU wait time", "err", err)
+		} else {
+			jm.gpuAvgWaitTime = gpuWaitTime
+		}
 	}
-	if len(startTimes) == 0 {
-		jm.startTime = 0
-	} else if startTime, err := stats.Mean(startTimes); err != nil {
-		level.Error(jc.logger).Log("msg", "Unable to calculate mean start time", "err", err)
-	} else {
-		jm.startTime = startTime
+	if len(startTimes) > 0 {
+		if startTime, err := stats.Median(startTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate median start time", "err", err)
+		} else {
+			jm.medianStartTime = startTime
+		}
+		if startTime, err := stats.Mean(startTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate average start time", "err", err)
+		} else {
+			jm.avgStartTime = startTime
+		}
 	}
-	if len(startTimesGpu) == 0 {
-		jm.startTimeGpu = 0
-	} else if startTimeGpu, err := stats.Mean(startTimesGpu); err != nil {
-		level.Error(jc.logger).Log("msg", "Unable to calculate mean GPU start time", "err", err)
-	} else {
-		jm.startTimeGpu = startTimeGpu
+	if len(gpuStartTimes) > 0 {
+		if gpuStartTime, err := stats.Median(gpuStartTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate median GPU start time", "err", err)
+		} else {
+			jm.gpuMedianStartTime = gpuStartTime
+		}
+		if gpuStartTime, err := stats.Mean(gpuStartTimes); err != nil {
+			level.Error(jc.logger).Log("msg", "Unable to calculate average GPU start time", "err", err)
+		} else {
+			jm.gpuAvgStartTime = gpuStartTime
+		}
 	}
 
 	return &jm, err
@@ -322,10 +358,10 @@ func (jc *JobsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- jc.preempted
 	ch <- jc.nodeFail
 	ch <- jc.total
-	ch <- jc.waitTime
-	ch <- jc.waitTimeGpu
-	ch <- jc.startTime
-	ch <- jc.startTimeGpu
+	ch <- jc.medianWaitTime
+	ch <- jc.avgWaitTime
+	ch <- jc.medianStartTime
+	ch <- jc.avgStartTime
 	ch <- jc.gpuPending
 	ch <- jc.gpuPendingDep
 	ch <- jc.gpuRunning
@@ -339,6 +375,10 @@ func (jc *JobsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- jc.gpuPreempted
 	ch <- jc.gpuNodeFail
 	ch <- jc.gpuTotal
+	ch <- jc.gpuMedianWaitTime
+	ch <- jc.gpuAvgWaitTime
+	ch <- jc.gpuMedianStartTime
+	ch <- jc.gpuAvgStartTime
 }
 
 func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
@@ -360,10 +400,10 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(jc.preempted, prometheus.GaugeValue, jm.preempted)
 	ch <- prometheus.MustNewConstMetric(jc.nodeFail, prometheus.GaugeValue, jm.nodeFail)
 	ch <- prometheus.MustNewConstMetric(jc.total, prometheus.GaugeValue, jm.total)
-	ch <- prometheus.MustNewConstMetric(jc.waitTime, prometheus.GaugeValue, jm.waitTime)
-	ch <- prometheus.MustNewConstMetric(jc.waitTimeGpu, prometheus.GaugeValue, jm.waitTimeGpu)
-	ch <- prometheus.MustNewConstMetric(jc.startTime, prometheus.GaugeValue, jm.startTime)
-	ch <- prometheus.MustNewConstMetric(jc.startTimeGpu, prometheus.GaugeValue, jm.startTimeGpu)
+	ch <- prometheus.MustNewConstMetric(jc.medianWaitTime, prometheus.GaugeValue, jm.medianWaitTime)
+	ch <- prometheus.MustNewConstMetric(jc.avgWaitTime, prometheus.GaugeValue, jm.avgWaitTime)
+	ch <- prometheus.MustNewConstMetric(jc.medianStartTime, prometheus.GaugeValue, jm.medianStartTime)
+	ch <- prometheus.MustNewConstMetric(jc.avgStartTime, prometheus.GaugeValue, jm.avgStartTime)
 	ch <- prometheus.MustNewConstMetric(jc.gpuPending, prometheus.GaugeValue, jm.gpuPending)
 	ch <- prometheus.MustNewConstMetric(jc.gpuPendingDep, prometheus.GaugeValue, jm.gpuPendingDep)
 	ch <- prometheus.MustNewConstMetric(jc.gpuRunning, prometheus.GaugeValue, jm.gpuRunning)
@@ -377,5 +417,9 @@ func (jc *JobsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(jc.gpuPreempted, prometheus.GaugeValue, jm.gpuPreempted)
 	ch <- prometheus.MustNewConstMetric(jc.gpuNodeFail, prometheus.GaugeValue, jm.gpuNodeFail)
 	ch <- prometheus.MustNewConstMetric(jc.gpuTotal, prometheus.GaugeValue, jm.gpuTotal)
+	ch <- prometheus.MustNewConstMetric(jc.gpuMedianWaitTime, prometheus.GaugeValue, jm.gpuMedianWaitTime)
+	ch <- prometheus.MustNewConstMetric(jc.gpuAvgWaitTime, prometheus.GaugeValue, jm.gpuAvgWaitTime)
+	ch <- prometheus.MustNewConstMetric(jc.gpuMedianStartTime, prometheus.GaugeValue, jm.gpuMedianStartTime)
+	ch <- prometheus.MustNewConstMetric(jc.gpuAvgStartTime, prometheus.GaugeValue, jm.gpuAvgStartTime)
 	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, errValue, "jobs")
 }

--- a/main.go
+++ b/main.go
@@ -139,8 +139,10 @@ func metricsHandler(cfg *slurmrest.Configuration, logger log.Logger) http.Handle
 
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(NewNodesCollector(client, logger))
+		registry.MustRegister(NewPartitionNodesCollector(client, logger))
 		registry.MustRegister(NewSchedulerCollector(client, logger))
 		registry.MustRegister(NewJobsCollector(client, logger))
+		registry.MustRegister(NewPartitionJobsCollector(client, logger))
 		registry.MustRegister(NewLicensesCollector(client, logger))
 		gatherers := prometheus.Gatherers{registry, prometheus.DefaultGatherer}
 		h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{})

--- a/nodes.go
+++ b/nodes.go
@@ -40,19 +40,6 @@ const (
 var (
 	ignoreNodeFeatures = kingpin.Flag("collector.nodes.ignore-features",
 		"Regular expression of node features to ignore").Default("^$").String()
-	allocPattern   = regexp.MustCompile(`(?i)^ALLOC`)
-	compPattern    = regexp.MustCompile(`(?i)^COMP`)
-	downPattern    = regexp.MustCompile(`(?i)^DOWN`)
-	drainPattern   = regexp.MustCompile(`(?i)^DRAIN`)
-	failPattern    = regexp.MustCompile(`(?i)^FAIL`)
-	errPattern     = regexp.MustCompile(`(?i)^ERR`)
-	idlePattern    = regexp.MustCompile(`(?i)^IDLE`)
-	invalPattern   = regexp.MustCompile(`(?i)^INVAL`)
-	maintPattern   = regexp.MustCompile(`(?i)^MAINT`)
-	mixPattern     = regexp.MustCompile(`(?i)^MIX`)
-	plannedPattern = regexp.MustCompile(`(?i)^PLANNED`)
-	resvPattern    = regexp.MustCompile(`(?i)^RES`)
-	unknownPattern = regexp.MustCompile(`(?i)^UNKNOWN`)
 )
 
 type NodesCollector struct {

--- a/partition_jobs.go
+++ b/partition_jobs.go
@@ -1,0 +1,652 @@
+// Copyright 2020 University at Buffalo. All rights reserved.
+//
+// This file is part of SlurmExporter.
+//
+// SlurmExporter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SlurmExporter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SlurmExporter. If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/montanaflynn/stats"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ubccr/slurmrest"
+)
+
+const (
+	partJobsNamespace    = "partition_jobs"
+	partGPUJobsNamespace = "partition_jobs_gres_gpu"
+)
+
+type PartitionJobsCollector struct {
+	client             *slurmrest.APIClient
+	logger             log.Logger
+	pending            *prometheus.Desc
+	pendingDep         *prometheus.Desc
+	running            *prometheus.Desc
+	suspended          *prometheus.Desc
+	cancelled          *prometheus.Desc
+	completing         *prometheus.Desc
+	completed          *prometheus.Desc
+	configuring        *prometheus.Desc
+	failed             *prometheus.Desc
+	timeout            *prometheus.Desc
+	preempted          *prometheus.Desc
+	nodeFail           *prometheus.Desc
+	total              *prometheus.Desc
+	medianWaitTime     *prometheus.Desc
+	avgWaitTime        *prometheus.Desc
+	medianStartTime    *prometheus.Desc
+	avgStartTime       *prometheus.Desc
+	gpuPending         *prometheus.Desc
+	gpuPendingDep      *prometheus.Desc
+	gpuRunning         *prometheus.Desc
+	gpuSuspended       *prometheus.Desc
+	gpuCancelled       *prometheus.Desc
+	gpuCompleting      *prometheus.Desc
+	gpuCompleted       *prometheus.Desc
+	gpuConfiguring     *prometheus.Desc
+	gpuFailed          *prometheus.Desc
+	gpuTimeout         *prometheus.Desc
+	gpuPreempted       *prometheus.Desc
+	gpuNodeFail        *prometheus.Desc
+	gpuTotal           *prometheus.Desc
+	gpuMedianWaitTime  *prometheus.Desc
+	gpuAvgWaitTime     *prometheus.Desc
+	gpuMedianStartTime *prometheus.Desc
+	gpuAvgStartTime    *prometheus.Desc
+}
+
+type partitionJobMetrics struct {
+	pending            map[string]float64
+	pendingDep         map[string]float64
+	running            map[string]float64
+	suspended          map[string]float64
+	cancelled          map[string]float64
+	completing         map[string]float64
+	completed          map[string]float64
+	configuring        map[string]float64
+	failed             map[string]float64
+	timeout            map[string]float64
+	preempted          map[string]float64
+	nodeFail           map[string]float64
+	total              map[string]float64
+	medianWaitTime     map[string]float64
+	avgWaitTime        map[string]float64
+	medianStartTime    map[string]float64
+	avgStartTime       map[string]float64
+	gpuPending         map[string]float64
+	gpuPendingDep      map[string]float64
+	gpuRunning         map[string]float64
+	gpuSuspended       map[string]float64
+	gpuCancelled       map[string]float64
+	gpuCompleting      map[string]float64
+	gpuCompleted       map[string]float64
+	gpuConfiguring     map[string]float64
+	gpuFailed          map[string]float64
+	gpuTimeout         map[string]float64
+	gpuPreempted       map[string]float64
+	gpuNodeFail        map[string]float64
+	gpuTotal           map[string]float64
+	gpuMedianWaitTime  map[string]float64
+	gpuAvgWaitTime     map[string]float64
+	gpuMedianStartTime map[string]float64
+	gpuAvgStartTime    map[string]float64
+}
+
+func NewPartitionJobsCollector(client *slurmrest.APIClient, logger log.Logger) *PartitionJobsCollector {
+	labels := []string{"partition"}
+	waitLabels := []string{"partition", "reason"}
+	return &PartitionJobsCollector{
+		client: client,
+		logger: log.With(logger, "collector", "partition_jobs"),
+		pending: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "pending"),
+			"Pending jobs in the partition", labels, nil),
+		pendingDep: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "pending_dependency"),
+			"Pending jobs because of dependency in the partition", labels, nil),
+		running: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "running"),
+			"Running jobs in the partition", labels, nil),
+		suspended: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "suspended"),
+			"Suspended jobs in the partition", labels, nil),
+		cancelled: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "cancelled"),
+			"Cancelled jobs in the partition", labels, nil),
+		completing: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "completing"),
+			"Completing jobs in the partition", labels, nil),
+		completed: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "completed"),
+			"Completed jobs in the partition", labels, nil),
+		configuring: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "configuring"),
+			"Configuring jobs in the partition", labels, nil),
+		failed: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "failed"),
+			"Number of failed jobs in the partition", labels, nil),
+		timeout: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "timeout"),
+			"Jobs stopped by timeout in the partition", labels, nil),
+		preempted: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "preempted"),
+			"Number of preempted jobs in the partition", labels, nil),
+		nodeFail: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "node_fail"),
+			"Number of jobs stopped due to node fail in the partition", labels, nil),
+		total: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "total"),
+			"Total jobs in the partition", labels, nil),
+		medianWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "median_wait_time_seconds"),
+			"Median wait time of pending jobs in the partition", waitLabels, nil),
+		avgWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "average_wait_time_seconds"),
+			"Average wait time of pending jobs in the partition", waitLabels, nil),
+		medianStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "median_start_time_seconds"),
+			"Median estimated start time of pending jobs in the partition", waitLabels, nil),
+		avgStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partJobsNamespace, "average_start_time_seconds"),
+			"Average estimated start time of pending jobs in the partition", waitLabels, nil),
+		gpuPending: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "pending"),
+			"Pending gres/gpu jobs in the partition", labels, nil),
+		gpuPendingDep: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "pending_dependency"),
+			"Pending gres/gpu jobs because of dependency in the partition", labels, nil),
+		gpuRunning: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "running"),
+			"Running gres/gpu jobs in the partition", labels, nil),
+		gpuSuspended: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "suspended"),
+			"Suspended gres/gpu jobs in the partition", labels, nil),
+		gpuCancelled: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "cancelled"),
+			"Cancelled gres/gpu jobs in the partition", labels, nil),
+		gpuCompleting: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "completing"),
+			"Completing gres/gpu jobs in the partition", labels, nil),
+		gpuCompleted: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "completed"),
+			"Completed gres/gpu jobs in the partition", labels, nil),
+		gpuConfiguring: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "configuring"),
+			"Configuring gres/gpu jobs in the partition", labels, nil),
+		gpuFailed: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "failed"),
+			"Number of failed gres/gpu jobs in the partition", labels, nil),
+		gpuTimeout: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "timeout"),
+			"gres/gpu Jobs stopped by timeout in the partition", labels, nil),
+		gpuPreempted: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "preempted"),
+			"Number of preempted gres/gpu jobs in the partition", labels, nil),
+		gpuNodeFail: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "node_fail"),
+			"Number of gres/gpu jobs stopped due to node fail in the partition", labels, nil),
+		gpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "total"),
+			"Total gres/gpu jobs in the partition", labels, nil),
+		gpuMedianWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "median_wait_time_seconds"),
+			"Median wait time of pending jobs that requested GPU in the partition", waitLabels, nil),
+		gpuAvgWaitTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "average_wait_time_seconds"),
+			"Average wait time of pending jobs that requested GPU in the partition", waitLabels, nil),
+		gpuMedianStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "median_start_time_seconds"),
+			"Median estimated start time of pending jobs that requested GPU in the partition", waitLabels, nil),
+		gpuAvgStartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, partGPUJobsNamespace, "average_start_time_seconds"),
+			"Average estimated start time of pending jobs that requested GPU in the partition", waitLabels, nil),
+	}
+}
+
+func (pjc *PartitionJobsCollector) metrics() (*partitionJobMetrics, error) {
+	var pjm partitionJobMetrics
+	ignoredPattern := regexp.MustCompile(*ignorePartitions)
+
+	partitions, resp, err := pjc.client.SlurmApi.SlurmctldGetPartitions(context.Background()).Execute()
+	if err != nil {
+		level.Error(pjc.logger).Log("msg", "Failed to fetch partitions from slurm rest api", "err", err)
+		return &pjm, err
+	} else if resp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP response not OK while fetching partitions from slurm rest api")
+		level.Error(pjc.logger).Log("err", err, "status_code", resp.StatusCode)
+		return &pjm, err
+	} else if len(partitions.GetErrors()) > 0 {
+		for _, err := range partitions.GetErrors() {
+			level.Error(pjc.logger).Log("err", err.GetError())
+		}
+		return &pjm, fmt.Errorf("HTTP response contained %d errors", len(partitions.GetErrors()))
+	}
+	jobs, resp, err := pjc.client.SlurmApi.SlurmctldGetJobs(context.Background()).Execute()
+	if err != nil {
+		level.Error(pjc.logger).Log("msg", "Failed to fetch jobs from slurm rest api", "err", err)
+		return &pjm, err
+	} else if resp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP response not OK while fetching jobs from slurm rest api")
+		level.Error(pjc.logger).Log("err", err, "status_code", resp.StatusCode)
+		return &pjm, err
+	} else if len(jobs.GetErrors()) > 0 {
+		for _, err := range jobs.GetErrors() {
+			level.Error(pjc.logger).Log("err", err.GetError())
+		}
+		return &pjm, fmt.Errorf("HTTP response contained %d errors", len(jobs.GetErrors()))
+	}
+
+	pending := make(map[string]float64)
+	pendingDep := make(map[string]float64)
+	running := make(map[string]float64)
+	suspended := make(map[string]float64)
+	cancelled := make(map[string]float64)
+	completing := make(map[string]float64)
+	completed := make(map[string]float64)
+	configuring := make(map[string]float64)
+	failed := make(map[string]float64)
+	timeout := make(map[string]float64)
+	preempted := make(map[string]float64)
+	nodeFail := make(map[string]float64)
+	total := make(map[string]float64)
+	medianWaitTime := make(map[string]float64)
+	avgWaitTime := make(map[string]float64)
+	medianStartTime := make(map[string]float64)
+	avgStartTime := make(map[string]float64)
+	gpuPending := make(map[string]float64)
+	gpuPendingDep := make(map[string]float64)
+	gpuRunning := make(map[string]float64)
+	gpuSuspended := make(map[string]float64)
+	gpuCancelled := make(map[string]float64)
+	gpuCompleting := make(map[string]float64)
+	gpuCompleted := make(map[string]float64)
+	gpuConfiguring := make(map[string]float64)
+	gpuFailed := make(map[string]float64)
+	gpuTimeout := make(map[string]float64)
+	gpuPreempted := make(map[string]float64)
+	gpuNodeFail := make(map[string]float64)
+	gpuTotal := make(map[string]float64)
+	gpuMedianWaitTime := make(map[string]float64)
+	gpuAvgWaitTime := make(map[string]float64)
+	gpuMedianStartTime := make(map[string]float64)
+	gpuAvgStartTime := make(map[string]float64)
+	waitTimes := make(map[string][]float64)
+	startTimes := make(map[string][]float64)
+	gpuWaitTimes := make(map[string][]float64)
+	gpuStartTimes := make(map[string][]float64)
+
+	for _, p := range partitions.GetPartitions() {
+		if ignoredPattern.MatchString(p.GetName()) {
+			continue
+		}
+		waitKey := fmt.Sprintf("%s|", p.GetName())
+		pending[p.GetName()] = 0
+		pendingDep[p.GetName()] = 0
+		running[p.GetName()] = 0
+		suspended[p.GetName()] = 0
+		cancelled[p.GetName()] = 0
+		completing[p.GetName()] = 0
+		completed[p.GetName()] = 0
+		configuring[p.GetName()] = 0
+		failed[p.GetName()] = 0
+		timeout[p.GetName()] = 0
+		preempted[p.GetName()] = 0
+		nodeFail[p.GetName()] = 0
+		total[p.GetName()] = 0
+		medianWaitTime[waitKey] = 0
+		avgWaitTime[waitKey] = 0
+		medianStartTime[waitKey] = 0
+		avgStartTime[waitKey] = 0
+		gpuPending[p.GetName()] = 0
+		gpuPendingDep[p.GetName()] = 0
+		gpuRunning[p.GetName()] = 0
+		gpuSuspended[p.GetName()] = 0
+		gpuCancelled[p.GetName()] = 0
+		gpuCompleting[p.GetName()] = 0
+		gpuCompleted[p.GetName()] = 0
+		gpuConfiguring[p.GetName()] = 0
+		gpuFailed[p.GetName()] = 0
+		gpuTimeout[p.GetName()] = 0
+		gpuPreempted[p.GetName()] = 0
+		gpuNodeFail[p.GetName()] = 0
+		gpuTotal[p.GetName()] = 0
+		gpuMedianWaitTime[waitKey] = 0
+		gpuAvgWaitTime[waitKey] = 0
+		gpuMedianStartTime[waitKey] = 0
+		gpuAvgStartTime[waitKey] = 0
+	}
+
+	now := time.Now().Unix()
+
+	for _, j := range jobs.GetJobs() {
+		tres := parseTres(j.GetTresReqStr())
+		tresAlloc := parseTres(j.GetTresAllocStr())
+		partitions := strings.Split(j.GetPartition(), ",")
+
+		for _, p := range partitions {
+			if ignoredPattern.MatchString(p) {
+				continue
+			}
+			total[p]++
+			if tres.GresGpu > 0 {
+				gpuTotal[p]++
+			}
+			switch j.GetJobState() {
+			case "PENDING":
+				pending[p]++
+				if j.GetStateReason() == "Dependency" {
+					pendingDep[p]++
+				}
+				if tres.GresGpu > 0 {
+					gpuPending[p]++
+					if j.GetStateReason() == "Dependency" {
+						gpuPendingDep[p]++
+					}
+				}
+				waitKey := fmt.Sprintf("%s|%s", p, j.GetStateReason())
+				startTime := j.GetStartTime() - now
+				if startTime >= 0 {
+					startTimes[waitKey] = append(startTimes[waitKey], float64(startTime))
+					if tres.GresGpu > 0 {
+						gpuStartTimes[waitKey] = append(gpuStartTimes[waitKey], float64(startTime))
+					}
+				}
+				waitTime := now - j.GetSubmitTime()
+				waitTimes[waitKey] = append(waitTimes[waitKey], float64(waitTime))
+				if tres.GresGpu > 0 {
+					gpuWaitTimes[waitKey] = append(gpuWaitTimes[waitKey], float64(waitTime))
+				}
+			case "RUNNING":
+				running[p]++
+				if tresAlloc.GresGpu > 0 {
+					gpuRunning[p]++
+				}
+			case "SUSPENDED":
+				suspended[p]++
+				if tres.GresGpu > 0 {
+					gpuSuspended[p]++
+				}
+			case "CANCELLED":
+				cancelled[p]++
+				if tres.GresGpu > 0 {
+					gpuCancelled[p]++
+				}
+			case "COMPLETING":
+				completing[p]++
+				if tres.GresGpu > 0 {
+					gpuCompleting[p]++
+				}
+			case "COMPLETED":
+				completed[p]++
+				if tres.GresGpu > 0 {
+					gpuCompleted[p]++
+				}
+			case "CONFIGURING":
+				configuring[p]++
+				if tres.GresGpu > 0 {
+					gpuConfiguring[p]++
+				}
+			case "FAILED":
+				failed[p]++
+				if tres.GresGpu > 0 {
+					gpuFailed[p]++
+				}
+			case "TIMEOUT":
+				timeout[p]++
+				if tres.GresGpu > 0 {
+					gpuTimeout[p]++
+				}
+			case "PREEMPTED":
+				preempted[p]++
+				if tres.GresGpu > 0 {
+					gpuPreempted[p]++
+				}
+			case "NODE_FAIL":
+				nodeFail[p]++
+				if tres.GresGpu > 0 {
+					gpuFailed[p]++
+				}
+			}
+		}
+	}
+
+	for p, times := range waitTimes {
+		if len(times) == 0 {
+			continue
+		}
+		if time, err := stats.Median(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate median wait time", "key", p, "err", err)
+		} else {
+			medianWaitTime[p] = time
+		}
+		if time, err := stats.Mean(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate average wait time", "key", p, "err", err)
+		} else {
+			avgWaitTime[p] = time
+		}
+	}
+	for p, times := range startTimes {
+		if len(times) == 0 {
+			continue
+		}
+		if time, err := stats.Median(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate median start time", "key", p, "err", err)
+		} else {
+			medianStartTime[p] = time
+		}
+		if time, err := stats.Mean(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate average start time", "key", p, "err", err)
+		} else {
+			avgStartTime[p] = time
+		}
+	}
+	for p, times := range gpuWaitTimes {
+		if len(times) == 0 {
+			continue
+		}
+		if time, err := stats.Median(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate median GPU wait time", "key", p, "err", err)
+		} else {
+			gpuMedianWaitTime[p] = time
+		}
+		if time, err := stats.Mean(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate average GPU wait time", "key", p, "err", err)
+		} else {
+			gpuAvgWaitTime[p] = time
+		}
+	}
+	for p, times := range gpuStartTimes {
+		if len(times) == 0 {
+			continue
+		}
+		if time, err := stats.Median(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate median GPU start time", "key", p, "err", err)
+		} else {
+			gpuMedianStartTime[p] = time
+		}
+		if time, err := stats.Mean(times); err != nil {
+			level.Error(pjc.logger).Log("msg", "Unable to calculate average GPU start time", "key", p, "err", err)
+		} else {
+			gpuAvgStartTime[p] = time
+		}
+	}
+
+	pjm.pending = pending
+	pjm.pendingDep = pendingDep
+	pjm.running = running
+	pjm.suspended = suspended
+	pjm.cancelled = suspended
+	pjm.completing = completing
+	pjm.completed = completed
+	pjm.configuring = configuring
+	pjm.failed = failed
+	pjm.timeout = timeout
+	pjm.preempted = preempted
+	pjm.nodeFail = nodeFail
+	pjm.total = total
+	pjm.medianWaitTime = medianWaitTime
+	pjm.avgWaitTime = avgWaitTime
+	pjm.medianStartTime = medianStartTime
+	pjm.avgStartTime = avgStartTime
+	pjm.gpuPending = gpuPending
+	pjm.gpuPendingDep = gpuPendingDep
+	pjm.gpuRunning = gpuRunning
+	pjm.gpuSuspended = gpuSuspended
+	pjm.gpuCancelled = gpuCancelled
+	pjm.gpuCompleting = gpuCompleting
+	pjm.gpuCompleted = gpuCompleted
+	pjm.gpuConfiguring = gpuConfiguring
+	pjm.gpuFailed = gpuFailed
+	pjm.gpuTimeout = gpuTimeout
+	pjm.gpuPreempted = gpuPreempted
+	pjm.gpuNodeFail = gpuNodeFail
+	pjm.gpuTotal = gpuTotal
+	pjm.gpuMedianWaitTime = gpuMedianWaitTime
+	pjm.gpuAvgWaitTime = gpuAvgWaitTime
+	pjm.gpuMedianStartTime = gpuMedianStartTime
+	pjm.gpuAvgStartTime = gpuAvgStartTime
+
+	return &pjm, err
+}
+
+func (pjc *PartitionJobsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- pjc.pending
+	ch <- pjc.pendingDep
+	ch <- pjc.running
+	ch <- pjc.suspended
+	ch <- pjc.cancelled
+	ch <- pjc.completing
+	ch <- pjc.completed
+	ch <- pjc.configuring
+	ch <- pjc.failed
+	ch <- pjc.timeout
+	ch <- pjc.preempted
+	ch <- pjc.nodeFail
+	ch <- pjc.total
+	ch <- pjc.medianWaitTime
+	ch <- pjc.avgWaitTime
+	ch <- pjc.medianStartTime
+	ch <- pjc.avgStartTime
+	ch <- pjc.gpuPending
+	ch <- pjc.gpuPendingDep
+	ch <- pjc.gpuRunning
+	ch <- pjc.gpuSuspended
+	ch <- pjc.gpuCancelled
+	ch <- pjc.gpuCompleting
+	ch <- pjc.gpuCompleted
+	ch <- pjc.gpuConfiguring
+	ch <- pjc.gpuFailed
+	ch <- pjc.gpuTimeout
+	ch <- pjc.gpuPreempted
+	ch <- pjc.gpuNodeFail
+	ch <- pjc.gpuTotal
+	ch <- pjc.gpuMedianWaitTime
+	ch <- pjc.gpuAvgWaitTime
+	ch <- pjc.gpuMedianStartTime
+	ch <- pjc.gpuAvgStartTime
+}
+
+func (pjc *PartitionJobsCollector) Collect(ch chan<- prometheus.Metric) {
+	var errValue float64
+	pjm, err := pjc.metrics()
+	if err != nil {
+		errValue = 1
+	}
+	for p, v := range pjm.pending {
+		ch <- prometheus.MustNewConstMetric(pjc.pending, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.pendingDep {
+		ch <- prometheus.MustNewConstMetric(pjc.pendingDep, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.pending {
+		ch <- prometheus.MustNewConstMetric(pjc.running, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.suspended {
+		ch <- prometheus.MustNewConstMetric(pjc.suspended, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.cancelled {
+		ch <- prometheus.MustNewConstMetric(pjc.cancelled, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.completing {
+		ch <- prometheus.MustNewConstMetric(pjc.completing, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.completed {
+		ch <- prometheus.MustNewConstMetric(pjc.completed, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.configuring {
+		ch <- prometheus.MustNewConstMetric(pjc.configuring, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.failed {
+		ch <- prometheus.MustNewConstMetric(pjc.failed, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.timeout {
+		ch <- prometheus.MustNewConstMetric(pjc.timeout, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.preempted {
+		ch <- prometheus.MustNewConstMetric(pjc.preempted, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.nodeFail {
+		ch <- prometheus.MustNewConstMetric(pjc.nodeFail, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.total {
+		ch <- prometheus.MustNewConstMetric(pjc.total, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.medianWaitTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.medianWaitTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.avgWaitTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.avgWaitTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.medianStartTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.medianStartTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.avgStartTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.avgStartTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.gpuPending {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuPending, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuPendingDep {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuPendingDep, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuRunning {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuRunning, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuSuspended {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuSuspended, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuCancelled {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuCancelled, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuCompleting {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuCompleting, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuCompleted {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuCompleted, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuConfiguring {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuConfiguring, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuFailed {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuFailed, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuTimeout {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuTimeout, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuPreempted {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuPreempted, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuNodeFail {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuNodeFail, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuTotal {
+		ch <- prometheus.MustNewConstMetric(pjc.gpuTotal, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pjm.gpuMedianWaitTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.gpuMedianWaitTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.gpuAvgWaitTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.gpuAvgWaitTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.gpuMedianStartTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.gpuMedianStartTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	for p, v := range pjm.gpuAvgStartTime {
+		keys := strings.Split(p, "|")
+		ch <- prometheus.MustNewConstMetric(pjc.gpuAvgStartTime, prometheus.GaugeValue, v, keys[0], keys[1])
+	}
+	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, errValue, "partition_jobs")
+}

--- a/partition_nodes.go
+++ b/partition_nodes.go
@@ -1,0 +1,424 @@
+// Copyright 2020 University at Buffalo. All rights reserved.
+//
+// This file is part of SlurmExporter.
+//
+// SlurmExporter is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SlurmExporter is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SlurmExporter. If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ubccr/slurmrest"
+)
+
+const (
+	partitionNodesNamespace = "partition_nodes"
+	partitionCpusNamespace  = "partition_cpus"
+	partitionGpusNamespace  = "partition_gpus"
+)
+
+type PartitionNodesCollector struct {
+	client   *slurmrest.APIClient
+	logger   log.Logger
+	alloc    *prometheus.Desc
+	comp     *prometheus.Desc
+	down     *prometheus.Desc
+	drain    *prometheus.Desc
+	err      *prometheus.Desc
+	fail     *prometheus.Desc
+	idle     *prometheus.Desc
+	inval    *prometheus.Desc
+	maint    *prometheus.Desc
+	mix      *prometheus.Desc
+	planned  *prometheus.Desc
+	reboot   *prometheus.Desc
+	resv     *prometheus.Desc
+	total    *prometheus.Desc
+	unknown  *prometheus.Desc
+	cpuAlloc *prometheus.Desc
+	cpuIdle  *prometheus.Desc
+	cpuOther *prometheus.Desc
+	cpuTotal *prometheus.Desc
+	gpuAlloc *prometheus.Desc
+	gpuIdle  *prometheus.Desc
+	gpuTotal *prometheus.Desc
+}
+
+type partitionNodeMetrics struct {
+	alloc    map[string]float64
+	comp     map[string]float64
+	down     map[string]float64
+	drain    map[string]float64
+	err      map[string]float64
+	fail     map[string]float64
+	idle     map[string]float64
+	inval    map[string]float64
+	maint    map[string]float64
+	mix      map[string]float64
+	planned  map[string]float64
+	reboot   map[string]float64
+	resv     map[string]float64
+	total    map[string]float64
+	unknown  map[string]float64
+	cpuAlloc map[string]float64
+	cpuIdle  map[string]float64
+	cpuOther map[string]float64
+	cpuTotal map[string]float64
+	gpuAlloc map[string]float64
+	gpuIdle  map[string]float64
+	gpuTotal map[string]float64
+}
+
+func NewPartitionNodesCollector(client *slurmrest.APIClient, logger log.Logger) *PartitionNodesCollector {
+	labels := []string{"partition"}
+	return &PartitionNodesCollector{
+		client: client,
+		logger: log.With(logger, "collector", "partition_nodes"),
+		alloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "alloc"),
+			"Allocated nodes in the partition", labels, nil),
+		comp: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "comp"),
+			"Completing nodes in the partition", labels, nil),
+		down: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "down"),
+			"Down nodes in the partition", labels, nil),
+		drain: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "drain"),
+			"Drain nodes in the partition", labels, nil),
+		err: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "err"),
+			"Error nodes in the partition", labels, nil),
+		fail: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "fail"),
+			"Fail nodes in the partition", labels, nil),
+		idle: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "idle"),
+			"Idle nodes in the partition", labels, nil),
+		inval: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "invalid"),
+			"Invalid nodes in the partition", labels, nil),
+		maint: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "maint"),
+			"Maint nodes in the partition", labels, nil),
+		mix: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "mix"),
+			"Mix nodes in the partition", labels, nil),
+		planned: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "planned"),
+			"Planned nodes in the partition", labels, nil),
+		reboot: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "reboot"),
+			"Reboot nodes in the partition", labels, nil),
+		resv: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "resv"),
+			"Reserved nodes in the partition", labels, nil),
+		total: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "total"),
+			"Total nodes in the partition", labels, nil),
+		unknown: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionNodesNamespace, "unknown"),
+			"Unknown nodes in the partition", labels, nil),
+		cpuAlloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionCpusNamespace, "alloc"),
+			"Allocated CPUs in the partition", labels, nil),
+		cpuIdle: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionCpusNamespace, "idle"),
+			"Idle CPUs in the partition", labels, nil),
+		cpuOther: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionCpusNamespace, "other"),
+			"Mix CPUs in the partition", labels, nil),
+		cpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionCpusNamespace, "total"),
+			"Total CPUs in the partition", labels, nil),
+		gpuAlloc: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionGpusNamespace, "alloc"),
+			"Allocated GPUs in the partition", labels, nil),
+		gpuIdle: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionGpusNamespace, "idle"),
+			"Idle GPUs in the partition", labels, nil),
+		gpuTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, partitionGpusNamespace, "total"),
+			"Total GPUs in the partition", labels, nil),
+	}
+}
+
+func (pnc *PartitionNodesCollector) metrics() (*partitionNodeMetrics, error) {
+	var pnm partitionNodeMetrics
+	ignoredPattern := regexp.MustCompile(*ignorePartitions)
+
+	partitions, resp, err := pnc.client.SlurmApi.SlurmctldGetPartitions(context.Background()).Execute()
+	if err != nil {
+		level.Error(pnc.logger).Log("msg", "Failed to fetch partitions from slurm rest api", "err", err)
+		return &pnm, err
+	} else if resp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP response not OK while fetching partitions from slurm rest api")
+		level.Error(pnc.logger).Log("err", err, "status_code", resp.StatusCode)
+		return &pnm, err
+	} else if len(partitions.GetErrors()) > 0 {
+		for _, err := range partitions.GetErrors() {
+			level.Error(pnc.logger).Log("err", err.GetError())
+		}
+		return &pnm, fmt.Errorf("HTTP response contained %d errors", len(partitions.GetErrors()))
+	}
+	nodeInfo, resp, err := pnc.client.SlurmApi.SlurmctldGetNodes(context.Background()).Execute()
+	if err != nil {
+		level.Error(pnc.logger).Log("msg", "Failed to fetch nodes from slurm rest api", "err", err)
+		return &pnm, err
+	} else if resp.StatusCode != 200 {
+		err = fmt.Errorf("HTTP response not OK while fetching nodes from slurm rest api")
+		level.Error(pnc.logger).Log("err", err, "status_code", resp.StatusCode)
+		return &pnm, err
+	} else if len(nodeInfo.GetErrors()) > 0 {
+		for _, err := range nodeInfo.GetErrors() {
+			level.Error(pnc.logger).Log("err", err.GetError())
+		}
+		return &pnm, fmt.Errorf("HTTP response contained %d errors", len(nodeInfo.GetErrors()))
+	}
+
+	alloc := make(map[string]float64)
+	comp := make(map[string]float64)
+	down := make(map[string]float64)
+	drain := make(map[string]float64)
+	errNodes := make(map[string]float64)
+	fail := make(map[string]float64)
+	idle := make(map[string]float64)
+	inval := make(map[string]float64)
+	maint := make(map[string]float64)
+	mix := make(map[string]float64)
+	planned := make(map[string]float64)
+	reboot := make(map[string]float64)
+	resv := make(map[string]float64)
+	total := make(map[string]float64)
+	unknown := make(map[string]float64)
+	cpuAlloc := make(map[string]float64)
+	cpuIdle := make(map[string]float64)
+	cpuOther := make(map[string]float64)
+	cpuTotal := make(map[string]float64)
+	gpuAlloc := make(map[string]float64)
+	gpuIdle := make(map[string]float64)
+	gpuTotal := make(map[string]float64)
+
+	for _, p := range partitions.GetPartitions() {
+		if ignoredPattern.MatchString(p.GetName()) {
+			continue
+		}
+		alloc[p.GetName()] = 0
+		comp[p.GetName()] = 0
+		down[p.GetName()] = 0
+		drain[p.GetName()] = 0
+		errNodes[p.GetName()] = 0
+		fail[p.GetName()] = 0
+		idle[p.GetName()] = 0
+		inval[p.GetName()] = 0
+		maint[p.GetName()] = 0
+		mix[p.GetName()] = 0
+		planned[p.GetName()] = 0
+		reboot[p.GetName()] = 0
+		resv[p.GetName()] = 0
+		total[p.GetName()] = 0
+		unknown[p.GetName()] = 0
+		cpuAlloc[p.GetName()] = 0
+		cpuIdle[p.GetName()] = 0
+		cpuOther[p.GetName()] = 0
+		cpuTotal[p.GetName()] = 0
+		gpuAlloc[p.GetName()] = 0
+		gpuIdle[p.GetName()] = 0
+		gpuTotal[p.GetName()] = 0
+	}
+
+	for _, n := range nodeInfo.GetNodes() {
+		states := []string{n.GetState()}
+		if len(n.GetStateFlags()) > 0 {
+			states = n.GetStateFlags()
+		}
+		for _, p := range n.GetPartitions() {
+			total[p]++
+			for _, state := range states {
+				// Node states
+				switch {
+				case allocPattern.MatchString(state):
+					alloc[p]++
+				case compPattern.MatchString(state):
+					comp[p]++
+				case downPattern.MatchString(state):
+					down[p]++
+				case drainPattern.MatchString(state):
+					drain[p]++
+				case failPattern.MatchString(state):
+					fail[p]++
+				case errPattern.MatchString(state):
+					errNodes[p]++
+				case idlePattern.MatchString(state):
+					idle[p]++
+				case invalPattern.MatchString(state):
+					inval[p]++
+				case maintPattern.MatchString(state):
+					maint[p]++
+				case mixPattern.MatchString(state):
+					mix[p]++
+				case plannedPattern.MatchString(state):
+					planned[p]++
+				case rebootPattern.MatchString(state):
+					reboot[p]++
+				case resvPattern.MatchString(state):
+					resv[p]++
+				case unknownPattern.MatchString(state):
+					unknown[p]++
+				default:
+					unknown[p]++
+				}
+			}
+
+			var down float64
+			for _, state := range states {
+				if downPattern.MatchString(state) || drainPattern.MatchString(state) ||
+					invalPattern.MatchString(state) || failPattern.MatchString(state) {
+					down = 1
+				}
+			}
+
+			// CPUs
+			cpuTotal[p] += float64(n.GetCpus())
+			cpuAlloc[p] += float64(n.GetAllocCpus())
+
+			if down == 1 {
+				cpuOther[p] += float64(n.GetIdleCpus())
+			} else {
+				cpuIdle[p] += float64(n.GetIdleCpus())
+			}
+
+			// GPUs
+			tres := parseTres(n.GetTres())
+			if tres.GresGpu == 0 {
+				continue
+			}
+
+			tresUsed := parseTres(n.GetTresUsed())
+
+			gpuAlloc[p] += float64(tresUsed.GresGpu)
+			gpuTotal[p] += float64(tres.GresGpu)
+			gpuIdle[p] += float64(tres.GresGpu - tresUsed.GresGpu)
+		}
+	}
+
+	pnm.alloc = alloc
+	pnm.comp = comp
+	pnm.down = down
+	pnm.drain = drain
+	pnm.err = errNodes
+	pnm.fail = fail
+	pnm.idle = idle
+	pnm.inval = inval
+	pnm.maint = maint
+	pnm.mix = mix
+	pnm.planned = planned
+	pnm.reboot = reboot
+	pnm.resv = resv
+	pnm.total = total
+	pnm.unknown = unknown
+	pnm.cpuAlloc = cpuAlloc
+	pnm.cpuIdle = cpuIdle
+	pnm.cpuOther = cpuOther
+	pnm.cpuTotal = cpuTotal
+	pnm.gpuAlloc = gpuAlloc
+	pnm.gpuIdle = gpuIdle
+	pnm.gpuTotal = gpuTotal
+
+	return &pnm, nil
+}
+
+func (pnc *PartitionNodesCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- pnc.alloc
+	ch <- pnc.comp
+	ch <- pnc.down
+	ch <- pnc.drain
+	ch <- pnc.err
+	ch <- pnc.fail
+	ch <- pnc.idle
+	ch <- pnc.inval
+	ch <- pnc.maint
+	ch <- pnc.mix
+	ch <- pnc.planned
+	ch <- pnc.reboot
+	ch <- pnc.resv
+	ch <- pnc.total
+	ch <- pnc.unknown
+	ch <- pnc.cpuAlloc
+	ch <- pnc.cpuIdle
+	ch <- pnc.cpuOther
+	ch <- pnc.cpuTotal
+	ch <- pnc.gpuAlloc
+	ch <- pnc.gpuIdle
+	ch <- pnc.gpuTotal
+}
+func (pnc *PartitionNodesCollector) Collect(ch chan<- prometheus.Metric) {
+	var errValue float64
+	pnm, err := pnc.metrics()
+	if err != nil {
+		errValue = 1
+	}
+	for p, v := range pnm.alloc {
+		ch <- prometheus.MustNewConstMetric(pnc.alloc, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.comp {
+		ch <- prometheus.MustNewConstMetric(pnc.comp, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.down {
+		ch <- prometheus.MustNewConstMetric(pnc.down, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.drain {
+		ch <- prometheus.MustNewConstMetric(pnc.drain, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.err {
+		ch <- prometheus.MustNewConstMetric(pnc.err, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.fail {
+		ch <- prometheus.MustNewConstMetric(pnc.fail, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.idle {
+		ch <- prometheus.MustNewConstMetric(pnc.idle, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.inval {
+		ch <- prometheus.MustNewConstMetric(pnc.inval, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.maint {
+		ch <- prometheus.MustNewConstMetric(pnc.maint, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.mix {
+		ch <- prometheus.MustNewConstMetric(pnc.mix, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.planned {
+		ch <- prometheus.MustNewConstMetric(pnc.planned, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.reboot {
+		ch <- prometheus.MustNewConstMetric(pnc.reboot, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.resv {
+		ch <- prometheus.MustNewConstMetric(pnc.resv, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.total {
+		ch <- prometheus.MustNewConstMetric(pnc.total, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.unknown {
+		ch <- prometheus.MustNewConstMetric(pnc.unknown, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.cpuAlloc {
+		ch <- prometheus.MustNewConstMetric(pnc.cpuAlloc, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.cpuIdle {
+		ch <- prometheus.MustNewConstMetric(pnc.cpuIdle, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.cpuOther {
+		ch <- prometheus.MustNewConstMetric(pnc.cpuOther, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.cpuTotal {
+		ch <- prometheus.MustNewConstMetric(pnc.cpuTotal, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.gpuAlloc {
+		ch <- prometheus.MustNewConstMetric(pnc.gpuAlloc, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.gpuIdle {
+		ch <- prometheus.MustNewConstMetric(pnc.gpuIdle, prometheus.GaugeValue, v, p)
+	}
+	for p, v := range pnm.gpuTotal {
+		ch <- prometheus.MustNewConstMetric(pnc.gpuTotal, prometheus.GaugeValue, v, p)
+	}
+	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, errValue, "partition_nodes")
+}

--- a/util.go
+++ b/util.go
@@ -25,14 +25,31 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
+	ignorePartitions = kingpin.Flag("collector.partition.ignore",
+		"Regexp of partitions to ignore").Default("^$").String()
 	// Regexp to parse GPU Gres and GresUsed strings. Example looks like this:
 	//   gpu:tesla_v100-pcie-16gb:2(S:0-1)
 	gpuGresPattern = regexp.MustCompile(`^gpu\:([^\:]+)\:?(\d+)?`)
 	collectError   = prometheus.NewDesc("slurm_exporter_collect_error",
 		"Indicates if an error has occurred during collection", []string{"collector"}, nil)
+	allocPattern   = regexp.MustCompile(`(?i)^ALLOC`)
+	compPattern    = regexp.MustCompile(`(?i)^COMP`)
+	downPattern    = regexp.MustCompile(`(?i)^DOWN`)
+	drainPattern   = regexp.MustCompile(`(?i)^DRAIN`)
+	failPattern    = regexp.MustCompile(`(?i)^FAIL`)
+	errPattern     = regexp.MustCompile(`(?i)^ERR`)
+	idlePattern    = regexp.MustCompile(`(?i)^IDLE`)
+	invalPattern   = regexp.MustCompile(`(?i)^INVAL`)
+	maintPattern   = regexp.MustCompile(`(?i)^MAINT`)
+	mixPattern     = regexp.MustCompile(`(?i)^MIX`)
+	plannedPattern = regexp.MustCompile(`(?i)^PLANNED`)
+	rebootPattern  = regexp.MustCompile(`(?i)^REBOOT`)
+	resvPattern    = regexp.MustCompile(`(?i)^RES`)
+	unknownPattern = regexp.MustCompile(`(?i)^UNKNOWN`)
 )
 
 type Tres struct {
@@ -103,4 +120,13 @@ func parseTres(line string) *Tres {
 	}
 
 	return &tres
+}
+
+func sliceContains(slice []string, str string) bool {
+	for _, s := range slice {
+		if str == s {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #11 

Also did a bit of variable name shuffle to make GPU metrics have `gpu` prefix and make it clear which are average and which are median.

The per-partition metrics have a lot of initialization code, that the metrics all have 0 for all partitions (that are not filtered) rather than sometimes simply having no values and being expired by Prometheus.

The metrics for jobs waiting/pending also have the reason as a label, which we find very useful when looking back at what kinds of pending reasons are accumulating on the clusters.  The median/average is done per-partition per-reason.